### PR TITLE
images:maker-image.bb

### DIFF
--- a/recipes-maker/images/maker-image.bb
+++ b/recipes-maker/images/maker-image.bb
@@ -18,7 +18,7 @@ IMAGE_INSTALL += "python-pip"
 IMAGE_INSTALL += "python-distribute"
 
 # Python libraries
-IMAGE_INSTALL += "mraa"
+IMAGE_INSTALL += "mraa python-mraa"
 # PyLab - consider moving these to their own image (~40MB)
 IMAGE_INSTALL += "python-numpy python-matplotlib"
 


### PR DESCRIPTION
mraa packages bindings separately now. This explicitly adds in the python bindings.

Signed-off-by: bavery brian.avery@intel.com
